### PR TITLE
Connectors list to Github pages

### DIFF
--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -152,7 +152,7 @@ jobs:
         for asset in $ASSETS
         do
           filename=$( basename $asset)
-          config=$( cat $(dirname $asset)/ow_config.json )
+          config=$( cat $( echo "$asset" | cut -d "/" -f2)/ow_config.json )
           DATA="$DATA{\"name\":\"${filename}\",\"file_path\":\"${asset}\",\"config\":${config}},"
         done
         POSTFIX="]"

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -23,6 +23,35 @@ jobs:
         USER_PASS: ${{ secrets.USER_PASS }}
     - name: WaitPre
       run: if grep pre .github/ngrok ; then bash .github/wait.sh ; fi
+
+    - name: Checkout to github-pages branch
+      id: checkout_to_gh_pages_branch
+      env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          BRANCH_NAME: 'gh-pages' 
+      run: |
+          #!/bin/sh
+          # check values
+          if [ -z "${GITHUB_TOKEN}" ]; then
+              echo "error: not found GITHUB_TOKEN"
+              exit 1
+          fi
+          if [ -z "${BRANCH_NAME}" ]; then
+             export BRANCH_NAME=master
+          fi
+          
+          remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config http.sslVerify false
+          git config user.name "Automated Publisher"
+          git config user.email "actions@users.noreply.github.com"
+          git remote add publisher "${remote_repo}"
+          git show-ref # useful for debugging
+          git fetch
+          git branch --verbose
+          
+          git lfs install
+          
+          git checkout ${BRANCH_NAME}
    
     - name: Build excel.node-10 connector
       id: build
@@ -112,20 +141,6 @@ jobs:
              export BRANCH_NAME=master
           fi
           
-          remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git config http.sslVerify false
-          git config user.name "Automated Publisher"
-          git config user.email "actions@users.noreply.github.com"
-          git remote add publisher "${remote_repo}"
-          git show-ref # useful for debugging
-          git fetch
-          git branch --verbose
-          
-          git lfs install
-          
-          git stash
-          git checkout ${BRANCH_NAME}
-          git stash apply
           git add index.json
           git add *.zip
           timestamp=$(date -u)

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     branches:
-      - dev/action_to_gh-pages
+      - master
 
 name: Build Connectors and Create Release
 

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     branches:
-      - master
+      - dev/action_to_gh-pages
 
 name: Build Connectors and Create Release
 

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -83,6 +83,28 @@ jobs:
         echo ::set-output name=postgresql_path::${POSTGRESQLPATH}
         echo ::set-output name=postgresql_name::${POSTGRESQLNAME}
 
+    - name: Build Go-Mongo
+      id: build_go_mongo
+      shell: bash
+      run: |
+        cd mongo.go && ./build.sh
+        ZIP_GO_NAME=$(ls main.zip)
+        ZIP_GO_PATH=$(realpath main.zip)
+        echo ::set-output name=zip_go_name::${ZIP_GO_NAME}
+        echo ::set-output name=zip_go_path::${ZIP_GO_PATH}
+        cd ..
+
+    - name: Build Node-GoogleSheet
+      id: build_node_googlesheet
+      shell: bash
+      run: |
+        cd googlesheet.node* && ./build.sh
+        ZIP_NODE_GOOGLESHEET_NAME=$(ls main.zip)
+        ZIP_NODE_GOOGLESHEET_PATH=$(realpath main.zip)
+        echo ::set-output name=zip_node_googlesheet_name::${ZIP_NODE_GOOGLESHEET_NAME}
+        echo ::set-output name=zip_node_googlesheet_path::${ZIP_NODE_GOOGLESHEET_PATH}
+        cd ..
+    
     - name: Create Connectors Json
       id: create_connectors_json
       run: |
@@ -99,7 +121,6 @@ jobs:
         OUTPUT="$PREFIX$DATA$POSTFIX"
         
         echo $OUTPUT > index.json
-        cat index.json
         
     - name: Add Binary Connectors to Repo
       id: add_binary_connectors_to_repo
@@ -116,7 +137,7 @@ jobs:
           if [ -z "${BRANCH_NAME}" ]; then
              export BRANCH_NAME=master
           fi
-          # initialize git
+          
           remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config http.sslVerify false
           git config user.name "Automated Publisher"
@@ -125,9 +146,9 @@ jobs:
           git show-ref # useful for debugging
           git fetch
           git branch --verbose
-          # install lfs hooks
+          
           git lfs install
-          # publish any new files
+          
           git checkout ${BRANCH_NAME}
           git add index.json
           git add *.zip

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -56,14 +56,14 @@ jobs:
         echo ::set-output name=zip_python_name::${ZIP_PYTHON_NAME}
         echo ::set-output name=zip_python_path::${ZIP_PYTHON_PATH}
         cd ..
-        
+
     - name: Build Node-GoogleSheet
       id: build_node_googlesheet
       shell: bash
       run: |
         cd googlesheet.node* && ./build.sh
-        ZIP_NODE_GOOGLESHEET_NAME=$(ls main.zip)
-        ZIP_NODE_GOOGLESHEET_PATH=$(realpath main.zip)
+        ZIP_NODE_GOOGLESHEET_NAME=$(ls googlesheet.node*.zip)
+        ZIP_NODE_GOOGLESHEET_PATH=$(realpath googlesheet.node*.zip)
         echo ::set-output name=zip_node_googlesheet_name::${ZIP_NODE_GOOGLESHEET_NAME}
         echo ::set-output name=zip_node_googlesheet_path::${ZIP_NODE_GOOGLESHEET_PATH}
         cd ..        
@@ -73,8 +73,8 @@ jobs:
       shell: bash
       run: |
         cd mongo.go && ./build.sh
-        ZIP_GO_NAME=$(ls main.zip)
-        ZIP_GO_PATH=$(realpath main.zip)
+        ZIP_GO_NAME=$(ls mongo.go*.zip)
+        ZIP_GO_PATH=$(realpath mongo.go*.zip)
         echo ::set-output name=zip_go_name::${ZIP_GO_NAME}
         echo ::set-output name=zip_go_path::${ZIP_GO_PATH}
         cd ..

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -72,7 +72,7 @@ jobs:
       id: build_go_mongo
       shell: bash
       run: |
-        cd mongo.go && ./build.sh
+        cd mongo.go && bash build.sh
         ZIP_GO_NAME=$(ls mongo.go*.zip)
         ZIP_GO_PATH=$(realpath mongo.go*.zip)
         echo ::set-output name=zip_go_name::${ZIP_GO_NAME}

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -78,32 +78,6 @@ jobs:
         echo ::set-output name=zip_go_name::${ZIP_GO_NAME}
         echo ::set-output name=zip_go_path::${ZIP_GO_PATH}
         cd ..
-
-    - name: Install java
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-
-    - name: Build database.java-8 connector
-      id: build_java
-      run: |
-        cd database.java* && make test && make release_mysql && make release_oracle && make release_sqlserver && make release_postgresql
-        MYSQLPATH=$(realpath build/distributions/mysql.java*.zip)
-        MYSQLNAME=$(basename build/distributions/mysql.java*.zip)
-        ORACLEPATH=$(realpath build/distributions/oracle.java*.zip)
-        ORACLENAME=$(basename build/distributions/oracle.java*.zip)
-        SQLSERVERPATH=$(realpath build/distributions/sqlserver.java*.zip)
-        SQLSERVERNAME=$(basename build/distributions/sqlserver.java*.zip)
-        POSTGRESQLPATH=$(realpath build/distributions/postgresql.java*.zip)
-        POSTGRESQLNAME=$(basename build/distributions/postgresql.java*.zip)
-        echo ::set-output name=mysql_path::${MYSQLPATH}
-        echo ::set-output name=mysql_name::${MYSQLNAME}
-        echo ::set-output name=oracle_path::${ORACLEPATH}
-        echo ::set-output name=oracle_name::${ORACLENAME}
-        echo ::set-output name=sqlserver_path::${SQLSERVERPATH}
-        echo ::set-output name=sqlserver_name::${SQLSERVERNAME}
-        echo ::set-output name=postgresql_path::${POSTGRESQLPATH}
-        echo ::set-output name=postgresql_name::${POSTGRESQLNAME}
     
     - name: Create Connectors Json
       id: create_connectors_json
@@ -149,7 +123,9 @@ jobs:
           
           git lfs install
           
+          git stash
           git checkout ${BRANCH_NAME}
+          git stash apply
           git add index.json
           git add *.zip
           timestamp=$(date -u)

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -1,0 +1,143 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    branches:
+      - dev/action_to_gh-pages
+
+name: Build Connectors and Create Release
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: NgrokPre
+      run: if grep pre .github/ngrok ; then bash .github/debug-github-actions.sh ; fi
+      env:
+        NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+        USER_PASS: ${{ secrets.USER_PASS }}
+    - name: WaitPre
+      run: if grep pre .github/ngrok ; then bash .github/wait.sh ; fi
+   
+    - name: Build excel.node-10 connector
+      id: build
+      shell: bash
+      run: |
+        cd excel.node* && ./build.sh
+        ZIP_NAME=$(ls excel.node*.zip)
+        ZIP_PATH=$(realpath excel.node*.zip)
+        echo ::set-output name=zip_name::${ZIP_NAME}
+        echo ::set-output name=zip_path::${ZIP_PATH}
+        cd ..
+  
+    - name: Build database.php-7.4 connector
+      id: build_php
+      shell: bash
+      run: |
+        cd database.php* && ./build.sh
+        ZIP_PHP_NAME=$(ls database.php*.zip)
+        ZIP_PHP_PATH=$(realpath database.php*.zip)
+        echo ::set-output name=zip_php_name::${ZIP_PHP_NAME}
+        echo ::set-output name=zip_php_path::${ZIP_PHP_PATH}
+        cd ..
+
+    - name: Build graphql.python-3 connector
+      id: build_python
+      shell: bash
+      run: |
+        cd graphql.python* && ./build.sh
+        ZIP_PYTHON_NAME=$(ls graphql.python*.zip)
+        ZIP_PYTHON_PATH=$(realpath graphql.python*.zip)
+        echo ::set-output name=zip_python_name::${ZIP_PYTHON_NAME}
+        echo ::set-output name=zip_python_path::${ZIP_PYTHON_PATH}
+        cd ..
+
+    - name: Install java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Build database.java-8 connector
+      id: build_java
+      run: |
+        cd database.java* && make test && make release_mysql && make release_oracle && make release_sqlserver && make release_postgresql
+        MYSQLPATH=$(realpath build/distributions/mysql.java*.zip)
+        MYSQLNAME=$(basename build/distributions/mysql.java*.zip)
+        ORACLEPATH=$(realpath build/distributions/oracle.java*.zip)
+        ORACLENAME=$(basename build/distributions/oracle.java*.zip)
+        SQLSERVERPATH=$(realpath build/distributions/sqlserver.java*.zip)
+        SQLSERVERNAME=$(basename build/distributions/sqlserver.java*.zip)
+        POSTGRESQLPATH=$(realpath build/distributions/postgresql.java*.zip)
+        POSTGRESQLNAME=$(basename build/distributions/postgresql.java*.zip)
+        echo ::set-output name=mysql_path::${MYSQLPATH}
+        echo ::set-output name=mysql_name::${MYSQLNAME}
+        echo ::set-output name=oracle_path::${ORACLEPATH}
+        echo ::set-output name=oracle_name::${ORACLENAME}
+        echo ::set-output name=sqlserver_path::${SQLSERVERPATH}
+        echo ::set-output name=sqlserver_name::${SQLSERVERNAME}
+        echo ::set-output name=postgresql_path::${POSTGRESQLPATH}
+        echo ::set-output name=postgresql_name::${POSTGRESQLNAME}
+
+    - name: Create Connectors Json
+      id: create_connectors_json
+      run: |
+        ASSETS=$(find . -type f -name '*.zip' -exec ls {} \;)
+        PREFIX="["
+        DATA=""
+        for asset in $ASSETS
+        do
+          filename=$( basename $asset)
+          DATA="$DATA{\"name\":\"${filename}\",\"file_path\":\"${asset}\"},"
+        done
+        POSTFIX="]"
+        DATA=${DATA::${#DATA}-1}
+        OUTPUT="$PREFIX$DATA$POSTFIX"
+        
+        echo $OUTPUT > index.json
+        
+    - name: Add Binary Connectors to Repo
+      id: add_binary_connectors_to_repo
+      env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          BRANCH_NAME: 'gh-pages' 
+      run: |
+          #!/bin/sh
+          # check values
+          if [ -z "${GITHUB_TOKEN}" ]; then
+              echo "error: not found GITHUB_TOKEN"
+              exit 1
+          fi
+          if [ -z "${BRANCH_NAME}" ]; then
+             export BRANCH_NAME=master
+          fi
+          # initialize git
+          remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config http.sslVerify false
+          git config user.name "Automated Publisher"
+          git config user.email "actions@users.noreply.github.com"
+          git remote add publisher "${remote_repo}"
+          git show-ref # useful for debugging
+          git branch --verbose
+          # install lfs hooks
+          git lfs install
+          # publish any new files
+          git checkout ${BRANCH_NAME}
+          git add index.json
+          git add *.zip
+          timestamp=$(date -u)
+          git commit -m "Automated publish: ${timestamp} ${GITHUB_SHA}" || exit 0
+          git pull --rebase publisher ${BRANCH_NAME}
+          git push publisher ${BRANCH_NAME}
+
+    - name: NgrokPost
+      run: if grep post .github/ngrok ; then bash .github/debug-github-actions.sh ; fi
+      env:
+        NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+        USER_PASS: ${{ secrets.USER_PASS }}
+    - name: WaitPost
+      run: if grep post .github/ngrok ; then bash .github/wait.sh ; fi

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -99,6 +99,7 @@ jobs:
         OUTPUT="$PREFIX$DATA$POSTFIX"
         
         echo $OUTPUT > index.json
+        cat index.json
         
     - name: Add Binary Connectors to Repo
       id: add_binary_connectors_to_repo
@@ -122,6 +123,7 @@ jobs:
           git config user.email "actions@users.noreply.github.com"
           git remote add publisher "${remote_repo}"
           git show-ref # useful for debugging
+          git fetch
           git branch --verbose
           # install lfs hooks
           git lfs install

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -56,6 +56,28 @@ jobs:
         echo ::set-output name=zip_python_name::${ZIP_PYTHON_NAME}
         echo ::set-output name=zip_python_path::${ZIP_PYTHON_PATH}
         cd ..
+        
+    - name: Build Node-GoogleSheet
+      id: build_node_googlesheet
+      shell: bash
+      run: |
+        cd googlesheet.node* && ./build.sh
+        ZIP_NODE_GOOGLESHEET_NAME=$(ls main.zip)
+        ZIP_NODE_GOOGLESHEET_PATH=$(realpath main.zip)
+        echo ::set-output name=zip_node_googlesheet_name::${ZIP_NODE_GOOGLESHEET_NAME}
+        echo ::set-output name=zip_node_googlesheet_path::${ZIP_NODE_GOOGLESHEET_PATH}
+        cd ..        
+
+    - name: Build Go-Mongo
+      id: build_go_mongo
+      shell: bash
+      run: |
+        cd mongo.go && ./build.sh
+        ZIP_GO_NAME=$(ls main.zip)
+        ZIP_GO_PATH=$(realpath main.zip)
+        echo ::set-output name=zip_go_name::${ZIP_GO_NAME}
+        echo ::set-output name=zip_go_path::${ZIP_GO_PATH}
+        cd ..
 
     - name: Install java
       uses: actions/setup-java@v1
@@ -82,28 +104,6 @@ jobs:
         echo ::set-output name=sqlserver_name::${SQLSERVERNAME}
         echo ::set-output name=postgresql_path::${POSTGRESQLPATH}
         echo ::set-output name=postgresql_name::${POSTGRESQLNAME}
-
-    - name: Build Go-Mongo
-      id: build_go_mongo
-      shell: bash
-      run: |
-        cd mongo.go && ./build.sh
-        ZIP_GO_NAME=$(ls main.zip)
-        ZIP_GO_PATH=$(realpath main.zip)
-        echo ::set-output name=zip_go_name::${ZIP_GO_NAME}
-        echo ::set-output name=zip_go_path::${ZIP_GO_PATH}
-        cd ..
-
-    - name: Build Node-GoogleSheet
-      id: build_node_googlesheet
-      shell: bash
-      run: |
-        cd googlesheet.node* && ./build.sh
-        ZIP_NODE_GOOGLESHEET_NAME=$(ls main.zip)
-        ZIP_NODE_GOOGLESHEET_PATH=$(realpath main.zip)
-        echo ::set-output name=zip_node_googlesheet_name::${ZIP_NODE_GOOGLESHEET_NAME}
-        echo ::set-output name=zip_node_googlesheet_path::${ZIP_NODE_GOOGLESHEET_PATH}
-        cd ..
     
     - name: Create Connectors Json
       id: create_connectors_json

--- a/.github/workflows/gh-pages_workflow.yml
+++ b/.github/workflows/gh-pages_workflow.yml
@@ -117,7 +117,8 @@ jobs:
         for asset in $ASSETS
         do
           filename=$( basename $asset)
-          DATA="$DATA{\"name\":\"${filename}\",\"file_path\":\"${asset}\"},"
+          config=$( cat $(dirname $asset)/ow_config.json )
+          DATA="$DATA{\"name\":\"${filename}\",\"file_path\":\"${asset}\",\"config\":${config}},"
         done
         POSTFIX="]"
         DATA=${DATA::${#DATA}-1}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mongo.go/.env-test
 mongo.go/main.zip
 mongo.go/commands.txt
+index.json

--- a/database.java-8/ow_config.json
+++ b/database.java-8/ow_config.json
@@ -1,0 +1,35 @@
+{
+    "main": "Main",
+    "kind": "blackbox",
+    "image": "openwhisk/actionloop-java-v8:nightly",
+    "params": [
+        {
+            "value": "databaseType",
+            "description": "Database Type"
+        },
+        {
+            "value": "host",
+            "description": "Database Host"
+        },
+        {
+            "value": "port",
+            "description": "Database Port"
+        },
+        {
+            "value": "sid",
+            "description": "SID"
+        },
+        {
+            "value": "database",
+            "description": "Database Name"
+        },
+        {
+            "value": "user",
+            "description": "Database User"
+        },
+        {
+            "value": "password",
+            "description": "Database Password"
+        }
+    ]
+}

--- a/database.php-7.4/ow_config.json
+++ b/database.php-7.4/ow_config.json
@@ -1,0 +1,27 @@
+{
+    "main": "main",
+    "kind": "php:7.4",
+    "image": "",
+    "params": [
+        {
+            "value": "dbhost",
+            "description": "Postgres Database Host"
+        },
+        {
+            "value": "dbport",
+            "description": "Postgres Database Port"
+        },
+        {
+            "value": "dbname",
+            "description": "Postgres Database Name"
+        },
+        {
+            "value": "dbuser",
+            "description": "Postgres Database User"
+        },
+        {
+            "value": "dbpass",
+            "description": "Postgres Database Password"
+        }
+    ]
+}

--- a/excel.node-10/ow_config.json
+++ b/excel.node-10/ow_config.json
@@ -1,0 +1,11 @@
+{
+    "main": "main",
+    "kind": "node:10",
+    "image": "",
+    "params": [
+        {
+            "value": "file",
+            "description": "Base64 File"
+        }
+    ]
+}

--- a/excel.node-10/ow_config.json
+++ b/excel.node-10/ow_config.json
@@ -1,6 +1,6 @@
 {
     "main": "main",
-    "kind": "node:10",
+    "kind": "nodejs:10",
     "image": "",
     "params": [
         {

--- a/googlesheet.node.ts-10/build.sh
+++ b/googlesheet.node.ts-10/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd "$(dirname $0)"
+ZIP_FILE=$(basename $(pwd)).zip
 if ! test -d node_modules
 then echo "downloading libraries, please wait..."
      npm install
@@ -10,7 +11,7 @@ then echo "preparing archive, please wait..."
 fi
 npm run tsc
 cd dist
-zip -u ../index.zip *.js -x *.test.js
+zip -u ../$ZIP_FILE *.js -x *.test.js
 cd ..
-wsk action update iosdk/import index.zip --kind nodejs:10 --web true
+#wsk action update iosdk/import index.zip --kind nodejs:10 --web true
  

--- a/googlesheet.node.ts-10/build.sh
+++ b/googlesheet.node.ts-10/build.sh
@@ -5,9 +5,9 @@ if ! test -d node_modules
 then echo "downloading libraries, please wait..."
      npm install
 fi
-if ! test -f index.zip 
+if ! test -f $ZIP_FILE 
 then echo "preparing archive, please wait..."
-     zip -qr index.zip node_modules
+     zip -qr $ZIP_FILE node_modules
 fi
 npm run tsc
 cd dist

--- a/googlesheet.node.ts-10/build.sh
+++ b/googlesheet.node.ts-10/build.sh
@@ -10,7 +10,7 @@ then echo "preparing archive, please wait..."
      zip -qr $ZIP_FILE node_modules
 fi
 npm run tsc
-cd dist
+cd dist || { echo "dist directory not found, aborting..."; exit 1; }
 zip -u ../$ZIP_FILE *.js -x *.test.js
 cd ..
 #wsk action update iosdk/import index.zip --kind nodejs:10 --web true

--- a/googlesheet.node.ts-10/ow_config.json
+++ b/googlesheet.node.ts-10/ow_config.json
@@ -1,0 +1,23 @@
+{
+    "main": "main",
+    "kind": "node:10",
+    "image": "",
+    "params": [
+        {
+            "value": "credentials",
+            "description": "Google Credentials"
+        },
+        {
+            "value": "token",
+            "description": "Google Authentication Token"
+        },
+        {
+            "value": "spreadsheetid",
+            "description": "Google Spreadsheet ID"
+        },
+        {
+            "value": "sheetname",
+            "description": "Google Spreadsheet name"
+        }
+    ]
+}

--- a/googlesheet.node.ts-10/ow_config.json
+++ b/googlesheet.node.ts-10/ow_config.json
@@ -1,6 +1,6 @@
 {
     "main": "main",
-    "kind": "node:10",
+    "kind": "nodejs:10",
     "image": "",
     "params": [
         {

--- a/graphql.python-3/ow_config.json
+++ b/graphql.python-3/ow_config.json
@@ -1,0 +1,11 @@
+{
+    "main": "main",
+    "kind": "python:3",
+    "image": "",
+    "params": [
+        {
+            "value": "url",
+            "description": "GraphQL Host URL"
+        }
+    ]
+}

--- a/mongo.go/.gitignore
+++ b/mongo.go/.gitignore
@@ -1,5 +1,6 @@
 .env-test
 main.zip
+mongo.go.zip
 commands.txt
 
 pkg/

--- a/mongo.go/build.sh
+++ b/mongo.go/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd "$(dirname $0)"
 ZIP_FILE=$(basename $(pwd)).zip
-rm main.zip
+rm $ZIP_FILE
 
 cd "src"
 

--- a/mongo.go/build.sh
+++ b/mongo.go/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 cd "$(dirname $0)"
-
+ZIP_FILE=$(basename $(pwd)).zip
 rm main.zip
 
 cd "src"
 
-zip -r ../main.zip *
+zip -r ../$ZIP_FILE *
 
 cd ..
 
-wsk action update iosdk/import main.zip --kind go:1.11 --web true
+#wsk action update iosdk/import main.zip --kind go:1.11 --web true
  

--- a/mongo.go/build.sh
+++ b/mongo.go/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Creating Mongo zip package"
 cd "$(dirname $0)"
 ZIP_FILE=$(basename $(pwd)).zip
 rm $ZIP_FILE

--- a/mongo.go/ow_config.json
+++ b/mongo.go/ow_config.json
@@ -1,0 +1,19 @@
+{
+    "main": "main",
+    "kind": "go:1.11",
+    "image": "",
+    "params": [
+        {
+            "value": "mongoUrl",
+            "description": "MongoDB Host URL"
+        },
+        {
+            "value": "dbName",
+            "description": "Database Name"
+        },
+        {
+            "value": "collection",
+            "description": "Collection Name"
+        }
+    ]
+}


### PR DESCRIPTION
Added a workflow that generates all binary connectors, creates a list of them and push everything into a branch used for publish the github-pages.

To make it work:

- Create an orphan branch that we will use as github-pages branch
`git checkout --orphan gh-pages`
- Reset the git status to init
`git rm -rf .`
- Push the orphan branch
`git push -u origin gh-pages`

- Now enable the github pages pointing to the newly created branch
![2020-12-03_12-53](https://user-images.githubusercontent.com/22035831/101014731-9e145100-3566-11eb-8427-e5ade3714cea.png)

Now, when the master branch will be pushed, the `gh-pages` branch will be populated with the index.json and the binary connectors.

Decisions: 
* Decided to not split the workflows by each connector due to a lot of code duplication, maybe its my lack of knowledge about github actions, but splitting them leads to a lot of complexity.
* For testing purpose i kept the workflow to be triggered on master push intead of on tag. Can be easily changed.